### PR TITLE
Fix: Disable SSL certificate verification failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 To install ProxmoxVE_PHP_API, simply:
 
 ```bash
-composer require saleh7/proxmoxve_php_api @dev
+composer require saleh7/proxmox-ve_php_api @dev
 ```
 
 ## Usage

--- a/src/Request.php
+++ b/src/Request.php
@@ -24,7 +24,7 @@ class Request
      * Proxmox Api client
      * @param array $configure   hostname, username, password, realm, port
     */
-    public static function Login(array $configure, $verifySSL = false)
+    public static function Login(array $configure, $verifySSL = false, $verifyHost = false)
     {
         $check = false;
         self::$hostname = !empty($configure['hostname'])  ? $configure['hostname']  : $check = true;
@@ -35,16 +35,19 @@ class Request
         if ($check) {
             throw new ProxmoxException('Require in array [hostname], [username], [password], [realm], [port]');
         }
-        self::ticket($verifySSL);
+        self::ticket($verifySSL, $verifyHost);
     }
     /**
      * Create or verify authentication ticket.
      * POST /api2/json/access/ticket
     */
-    protected static function ticket($verifySSL)
+    protected static function ticket($verifySSL, $verifyHost)
     {
         self::$Client = new \Curl\Curl();
-        self::$Client->setOpt(CURLOPT_SSL_VERIFYPEER, $verifySSL);
+        self::$Client->setOpts([
+            CURLOPT_SSL_VERIFYPEER => $verifySSL,
+            CURLOPT_SSL_VERIFYHOST => $verifyHost
+        ]);
         $response = self::$Client->post("https://".self::$hostname.":".self::$port."/api2/json/access/ticket", array(
             'username'  => self::$username,
             'password'  => self::$password,


### PR DESCRIPTION
### SSL verification failed even when setting it to disabled.

`self::$Client = new \Curl\Curl();`
`self::$Client->setOpt(CURLOPT_SSL_VERIFYPEER => false);`
`$response = self::$Client->get("https://domain.name");`

**ERROR**
'SSL peer certificate or SSH remote key was not OK: SSL: no alternative certificate subject name matches target host name 'domain.name''