### PR TITLE
Fixing the content lenght on DELETE query

### DIFF
--- a/src/Request.php
+++ b/src/Request.php
@@ -85,6 +85,7 @@ class Request
              return self::$Client->post($api, $params);
              break;
            case "DELETE":
+             self::$Client->removeHeader('Content-Length');
              return self::$Client->delete($api, $params);
              break;
            default:


### PR DESCRIPTION
Hey,

I'm using you library for my projects and it came id handy a few times now :smile:

I've found a little issue with the delete method, Proxmox don't play nice at all if the Content-Length herder is set while calling the DELETE method.

My guess is Proxmox is using the content length to check if there is data in the body, since they should not it's rejecting the query.

This is and quick and easy fix, who should avoid a lot of debugging to others users :wink: